### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/resource/io_io.dart
+++ b/lib/src/resource/io_io.dart
@@ -87,7 +87,7 @@ Future<String> readAsString(Uri uri, Encoding encoding) async {
       var byteList = buffer.buffer.asUint8List(0, buffer.length);
       return new String.fromCharCodes(byteList);
     }
-    return response.transform(encoding.decoder).join();
+    return encoding.decoder.bind(response).join();
   }
   if (uri.scheme == "data") {
     return uri.data.contentAsString(encoding: encoding);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jose
 description: Javascript Object Signing and Encryption (JOSE) library supporting JWE, JWS, JWK and JWT
-version: 0.1.2
+version: 0.1.2+1
 author: Rik Bellens <rik.bellens@appsup.be>
 homepage: https://github.com/appsup-dart/jose
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900