### PR TITLE
Accept JWKs with RSA certificate if they also provide modulus and exponent as parameters

### DIFF
--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -2,6 +2,7 @@
 library jose.jwk;
 
 import 'package:crypto_keys/crypto_keys.dart';
+import 'package:logging/logging.dart';
 import 'util.dart';
 import 'dart:async';
 import 'jose.dart';
@@ -428,6 +429,7 @@ class JsonWebKeySet extends JsonObject {
 
 /// A key store to lookup [JsonWebKey]s
 class JsonWebKeyStore {
+  final Logger log = new Logger('JsonWebKeyStore');
   final List<JsonWebKey> _keys = [];
   final List<JsonWebKeySet> _keySets = [];
   final List<Uri> _keySetUrls = [];
@@ -492,7 +494,7 @@ class JsonWebKeyStore {
         set = _addKeySetToCache(
             uri, JsonWebKeySet.fromJson(convert.json.decode(v)));
       } catch (e) {
-        // TODO log
+        log.warning('Could not load keys from $uri', e);
         return;
       }
     }

--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -19,11 +19,15 @@ class JsonWebKey extends JsonObject {
       : _keyPair = KeyPair.fromJwk(json),
         super.from(json) {
     if (keyType == null) throw ArgumentError.notNull('keyType');
-    if (json.containsKey('x5u') ||
-        json.containsKey('x5c') ||
-        json.containsKey('x5t') ||
-        json.containsKey('x5t#S256')) {
-      throw UnimplementedError('X.509 keys not implemented');
+    // If RSA and we already got the public key by other parameters we can skip
+    // the certificate check
+    if (keyType != 'RSA' || _keyPair.publicKey == null) {
+      if (json.containsKey('x5u') ||
+          json.containsKey('x5c') ||
+          json.containsKey('x5t') ||
+          json.containsKey('x5t#S256')) {
+        throw UnimplementedError('X.509 keys not implemented');
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   crypto_keys: ^0.1.0
+  logging: ^0.11.4
   meta: ^1.1.6
   typed_data: ^1.0.0
 

--- a/test/tests/jwk_test.dart
+++ b/test/tests/jwk_test.dart
@@ -192,4 +192,49 @@ void main() {
       expect(key.toJson(), json);
     }, skip: 'X.509 not implemented');
   });
+
+  test(
+      'Example Use of ignored "x5c" (X.509 Certificate Chain) Parameter if "n" and "e" are present',
+      () {
+    var json = {
+      'kty': 'RSA',
+      'use': 'sig',
+      'kid': '1b94c',
+      'n': 'vrjOfz9Ccdgx5nQudyhdoR17V-IubWMeOZCwX_jj0hgAsz2J_pqYW08'
+          'PLbK_PdiVGKPrqzmDIsLI7sA25VEnHU1uCLNwBuUiCO11_-7dYbsr4iJmG0Q'
+          'u2j8DsVyT1azpJC_NG84Ty5KKthuCaPod7iI7w0LK9orSMhBEwwZDCxTWq4a'
+          'YWAchc8t-emd9qOvWtVMDC2BXksRngh6X5bUYLy6AyHKvj-nUy1wgzjYQDwH'
+          'MTplCoLtU-o-8SNnZ1tmRoGE9uJkBLdh5gFENabWnU5m1ZqZPdwS-qo-meMv'
+          'VfJb6jJVWRpl2SUtCnYG2C32qvbWbjZ_jBPD5eunqsIo1vQ',
+      'e': 'AQAB',
+      'x5c': [
+        'MIIDQjCCAiqgAwIBAgIGATz/FuLiMA0GCSqGSIb3DQEBBQUAMGIxCzAJB'
+            'gNVBAYTAlVTMQswCQYDVQQIEwJDTzEPMA0GA1UEBxMGRGVudmVyMRwwGgYD'
+            'VQQKExNQaW5nIElkZW50aXR5IENvcnAuMRcwFQYDVQQDEw5CcmlhbiBDYW1'
+            'wYmVsbDAeFw0xMzAyMjEyMzI5MTVaFw0xODA4MTQyMjI5MTVaMGIxCzAJBg'
+            'NVBAYTAlVTMQswCQYDVQQIEwJDTzEPMA0GA1UEBxMGRGVudmVyMRwwGgYDV'
+            'QQKExNQaW5nIElkZW50aXR5IENvcnAuMRcwFQYDVQQDEw5CcmlhbiBDYW1w'
+            'YmVsbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL64zn8/QnH'
+            'YMeZ0LncoXaEde1fiLm1jHjmQsF/449IYALM9if6amFtPDy2yvz3YlRij66'
+            's5gyLCyO7ANuVRJx1NbgizcAblIgjtdf/u3WG7K+IiZhtELto/A7Fck9Ws6'
+            'SQvzRvOE8uSirYbgmj6He4iO8NCyvaK0jIQRMMGQwsU1quGmFgHIXPLfnpn'
+            'fajr1rVTAwtgV5LEZ4Iel+W1GC8ugMhyr4/p1MtcIM42EA8BzE6ZQqC7VPq'
+            'PvEjZ2dbZkaBhPbiZAS3YeYBRDWm1p1OZtWamT3cEvqqPpnjL1XyW+oyVVk'
+            'aZdklLQp2Btgt9qr21m42f4wTw+Xrp6rCKNb0CAwEAATANBgkqhkiG9w0BA'
+            'QUFAAOCAQEAh8zGlfSlcI0o3rYDPBB07aXNswb4ECNIKG0CETTUxmXl9KUL'
+            '+9gGlqCz5iWLOgWsnrcKcY0vXPG9J1r9AqBNTqNgHq2G03X09266X5CpOe1'
+            'zFo+Owb1zxtp3PehFdfQJ610CDLEaS9V9Rqp17hCyybEpOGVwe8fnk+fbEL'
+            '2Bo3UPGrpsHzUoaGpDftmWssZkhpBJKVMJyf/RuP2SmmaIzmnw9JiSlYhzo'
+            '4tpzd5rFXhjRbg4zW9C+2qok+2+qDM1iJ684gPHMIY8aLWrdgQTxkumGmTq'
+            'gawR+N5MDtdPTEQ0XfIBc2cJEUyMTY5MPvACWpkA6SdS4xSvdXK3IVfOWA=='
+      ]
+    };
+
+    var key = JsonWebKey.fromJson(json);
+
+    expect(key.keyType, 'RSA');
+    expect(key.usableForOperation('verify'), isTrue);
+
+    expect(key.toJson(), json);
+  });
 }


### PR DESCRIPTION
Some JWKs contain the 'n' and 'e' parameter in addition to the certificate parameters. In this case (according to 4.6. of [RFC7517]) the values are semantically equivalent to the ones in the certificate. Thus all information for the public key are available and no exception needs to be thrown in this situation.