### PR TITLE
Bump asn1lib to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.2.2
+- Bump `asn1lib` to 0.8.1.
+
 ## 0.2.1+1
 
 - Fix docs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,22 +1,21 @@
 name: jose
 description: Javascript Object Signing and Encryption (JOSE) library supporting JWE, JWS, JWK and JWT
-version: 0.2.1+1
+version: 0.2.2
 homepage: https://github.com/appsup-dart/jose
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: ">=2.5.0 <3.0.0"
 
 dependencies:
   crypto_keys: ^0.1.3
   meta: ^1.1.6
   typed_data: ^1.0.0
-  x509: ^0.1.2+1
+  x509: ^0.1.3
   http_extensions_cache: ^0.1.3
   http_extensions: ^0.1.2
   http: ^0.12.0
-  asn1lib: ^0.6.4
+  asn1lib: ^0.8.1
 
 dev_dependencies:
   test: ^1.0.0
   pedantic: ^1.9.0
-


### PR DESCRIPTION
This fixes some downstream versioning errors due to relying on an old version of asn1lib here.