### PR TITLE
Bugfix for jwk creation

### DIFF
--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -117,7 +117,8 @@ class JsonWebKey extends JsonObject {
       return JsonWebKey.ec(
           curve: _toCurveName(publicKey.curve),
           xCoordinate: publicKey.xCoordinate,
-          yCoordinate: publicKey.yCoordinate);
+          yCoordinate: publicKey.yCoordinate,
+          keyId: keyId);
     }
 
     throw UnsupportedError(


### PR DESCRIPTION
Fixed a bug where the keyid isn't supplied if a jwk to be constructed is a EcPublicKey.