### PR TITLE
Fixed type mismatch error on keyOperations getter

### DIFF
--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -278,7 +278,7 @@ class JsonWebKey extends JsonObject {
     _assertCanDo('verify');
     var verifier = _keyPair.publicKey!.createVerifier(_getAlgorithm(algorithm));
     return verifier.verify(
-        data as Uint8List, Signature(signature as Uint8List));
+        Uint8List.fromList(data), Signature(Uint8List.fromList(signature)));
   }
 
   /// Encrypt content
@@ -290,9 +290,9 @@ class JsonWebKey extends JsonObject {
     algorithm ??= this.algorithm;
     var encrypter =
         _keyPair.publicKey!.createEncrypter(_getAlgorithm(algorithm));
-    return encrypter.encrypt(data as Uint8List,
-        initializationVector: initializationVector as Uint8List?,
-        additionalAuthenticatedData: additionalAuthenticatedData as Uint8List?);
+    return encrypter.encrypt(Uint8List.fromList(data),
+        initializationVector: initializationVector != null ? Uint8List.fromList(initializationVector) : null,
+        additionalAuthenticatedData: additionalAuthenticatedData != null ? Uint8List.fromList(additionalAuthenticatedData) : null);
   }
 
   /// Decrypt content and validate decryption, if applicable
@@ -305,11 +305,11 @@ class JsonWebKey extends JsonObject {
     algorithm ??= this.algorithm;
     var decrypter =
         _keyPair.privateKey!.createEncrypter(_getAlgorithm(algorithm));
-    return decrypter.decrypt(EncryptionResult(data as Uint8List,
-        initializationVector: initializationVector as Uint8List?,
-        authenticationTag: authenticationTag as Uint8List?,
+    return decrypter.decrypt(EncryptionResult(Uint8List.fromList(data),
+        initializationVector: initializationVector != null ? Uint8List.fromList(initializationVector) : null,
+        authenticationTag: authenticationTag != null ? Uint8List.fromList(authenticationTag) : null,
         additionalAuthenticatedData:
-            additionalAuthenticatedData as Uint8List?));
+            additionalAuthenticatedData != null ? Uint8List.fromList(additionalAuthenticatedData) : null));
   }
 
   /// Encrypt key
@@ -321,7 +321,7 @@ class JsonWebKey extends JsonObject {
     algorithm ??= this.algorithm;
     var encrypter =
         _keyPair.publicKey!.createEncrypter(_getAlgorithm(algorithm));
-    var v = encrypter.encrypt(decodeBase64EncodedBytes(key['k']) as Uint8List);
+    var v = encrypter.encrypt(Uint8List.fromList(decodeBase64EncodedBytes(key['k'])));
     return v.data;
   }
 
@@ -331,7 +331,7 @@ class JsonWebKey extends JsonObject {
     algorithm ??= this.algorithm;
     var decrypter =
         _keyPair.privateKey!.createEncrypter(_getAlgorithm(algorithm));
-    var v = decrypter.decrypt(EncryptionResult(data as Uint8List));
+    var v = decrypter.decrypt(EncryptionResult(Uint8List.fromList(data)));
     return JsonWebKey.fromJson({
       'kty': 'oct',
       'k': encodeBase64EncodedBytes(v),

--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -230,7 +230,7 @@ class JsonWebKey extends JsonObject {
   ///
   /// Other values MAY be used.
   Set<String>? get keyOperations =>
-      getTypedList('key_ops')?.toSet() as Set<String>?;
+      getTypedList<String>('key_ops')?.toSet() as Set<String>?;
 
   /// The algorithm intended for use with the key.
   String? get algorithm => this['alg'];
@@ -415,7 +415,7 @@ class JsonWebKey extends JsonObject {
 class JsonWebKeySet extends JsonObject {
   /// An array of JWK values
   List<JsonWebKey> get keys =>
-      getTypedList('keys', factory: (v) => JsonWebKey.fromJson(v)) ?? const [];
+      getTypedList<JsonWebKey>('keys', factory: (v) => JsonWebKey.fromJson(v)) ?? const [];
 
   /// Constructs a [JsonWebKeySet] from the list of [keys]
   factory JsonWebKeySet.fromKeys(Iterable<JsonWebKey> keys) =>


### PR DESCRIPTION
When JWK object tries to get `keyOperations`, dart throws the error:
`type '_CompactLinkedHashSet<dynamic>' is not a subtype of type 'Set<String>?' in type cast`

Fixed it by setting particular type on calling `getTypedList`