### PR TITLE
migrate to dart 3, upgrade http, switch to 'lints' package from 'pedantic'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+ - **FEAT**: migrate to dart 3 ([#50](https://github.com/appsup-dart/jose/pull/50))
+
+
 ## 0.3.3
 
  - **FIX**: allow double values when converting to DateTime and Duration (pull request [#33](https://github.com/appsup-dart/jose/issues/33) from PixelToast). ([3b204b10](https://github.com/appsup-dart/jose/commit/3b204b10101c7db7dc275279dcc4090a1494d238))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.4.0
+## 0.3.4
 
- - **FEAT**: migrate to dart 3 ([#50](https://github.com/appsup-dart/jose/pull/50))
+ - **FEAT**: Support latest `package:http` ([#50](https://github.com/appsup-dart/jose/pull/50))
 
 
 ## 0.3.3

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,4 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/lib/src/jwa.dart
+++ b/lib/src/jwa.dart
@@ -1,4 +1,6 @@
 /// [JSON Web Algorithms](https://tools.ietf.org/html/rfc7518)
+// ignore_for_file: constant_identifier_names
+
 library jose.jwa;
 
 import 'package:crypto_keys/crypto_keys.dart';

--- a/lib/src/jwe.dart
+++ b/lib/src/jwe.dart
@@ -201,7 +201,7 @@ class JsonWebEncryptionBuilder extends JoseObjectBuilder<JsonWebEncryption> {
       'enc': encryptionAlgorithm
     };
 
-    var _recipients = recipients.map((r) {
+    var recipientsMapped = recipients.map((r) {
       var key = r['_jwk'] as JsonWebKey;
       var algorithm = r['alg'] ?? key.algorithmForOperation('wrapKey') ?? 'dir';
       if (algorithm == 'dir') {
@@ -252,7 +252,7 @@ class JsonWebEncryptionBuilder extends JoseObjectBuilder<JsonWebEncryption> {
     var encryptedData = cek.encrypt(data!,
         initializationVector: iv,
         additionalAuthenticatedData: Uint8List.fromList(aad.codeUnits));
-    return JsonWebEncryption._(encryptedData.data, _recipients,
+    return JsonWebEncryption._(encryptedData.data, recipientsMapped,
         protectedHeader: protectedHeader,
         unprotectedHeader:
             compact ? null : JsonObject.from(sharedUnprotectedHeaderParams),

--- a/lib/src/jwk.dart
+++ b/lib/src/jwk.dart
@@ -79,7 +79,7 @@ class JsonWebKey extends JsonObject {
       );
     }
 
-    String _toCurveName(Identifier? curve) {
+    String toCurveName(Identifier? curve) {
       return curvesByName.entries
           .firstWhere((element) => element.value == curve)
           .key;
@@ -92,7 +92,7 @@ class JsonWebKey extends JsonObject {
       }
 
       return JsonWebKey.ec(
-        curve: _toCurveName(privateKey.curve),
+        curve: toCurveName(privateKey.curve),
         privateKey: privateKey.eccPrivateKey,
         xCoordinate: (publicKey as EcPublicKey?)?.xCoordinate,
         yCoordinate: publicKey?.yCoordinate,
@@ -115,7 +115,7 @@ class JsonWebKey extends JsonObject {
 
     if (publicKey is EcPublicKey) {
       return JsonWebKey.ec(
-          curve: _toCurveName(publicKey.curve),
+          curve: toCurveName(publicKey.curve),
           xCoordinate: publicKey.xCoordinate,
           yCoordinate: publicKey.yCoordinate,
           keyId: keyId);
@@ -231,7 +231,7 @@ class JsonWebKey extends JsonObject {
   ///
   /// Other values MAY be used.
   Set<String>? get keyOperations =>
-      getTypedList<String>('key_ops')?.toSet() as Set<String>?;
+      getTypedList<String>('key_ops')?.toSet();
 
   /// The algorithm intended for use with the key.
   String? get algorithm => this['alg'];

--- a/lib/src/jws.dart
+++ b/lib/src/jws.dart
@@ -187,13 +187,13 @@ class JsonWebSignatureBuilder extends JoseObjectBuilder<JsonWebSignature> {
       throw StateError('No payload set');
     }
 
-    var _signatures = recipients.map((r) {
+    var signatures = recipients.map((r) {
       var key = r['_jwk'];
       var algorithm = r['alg'];
       return _JwsRecipient._sign(payload.data, payload.protectedHeader!, key,
           algorithm: algorithm, protectAll: recipients.length == 1);
     }).toList();
 
-    return JsonWebSignature._(payload.data, _signatures);
+    return JsonWebSignature._(payload.data, signatures);
   }
 }

--- a/lib/src/jws.dart
+++ b/lib/src/jws.dart
@@ -31,9 +31,9 @@ class JsonWebSignature extends JoseObject {
   /// Constructs a [JsonWebSignature] from its flattened or general JSON
   /// representation
   factory JsonWebSignature.fromJson(Map<String, dynamic> json) {
-    List<_JwsRecipient> signatures;
+    Iterable<_JwsRecipient> signatures;
     if (json.containsKey('signatures')) {
-      signatures = json['signatures'].map((v) => _JwsRecipient.fromJson(v));
+      signatures = (json['signatures'] as List<Map<String, Object>>).map((v) => _JwsRecipient.fromJson(v));
     } else {
       signatures = [_JwsRecipient.fromJson(json)];
     }

--- a/lib/src/jws.dart
+++ b/lib/src/jws.dart
@@ -31,7 +31,7 @@ class JsonWebSignature extends JoseObject {
   /// Constructs a [JsonWebSignature] from its flattened or general JSON
   /// representation
   factory JsonWebSignature.fromJson(Map<String, dynamic> json) {
-    var signatures;
+    List<_JwsRecipient> signatures;
     if (json.containsKey('signatures')) {
       signatures = json['signatures'].map((v) => _JwsRecipient.fromJson(v));
     } else {

--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -112,7 +112,7 @@ class JsonWebToken {
     var joseObject = JoseObject.fromCompactSerialization(serialization);
     var content = await joseObject.getPayload(keyStore,
         allowedAlgorithms: allowedArguments);
-    var claims;
+    JsonWebTokenClaims claims;
     if (content.mediaType == 'JWT') {
       claims = (await decodeAndVerify(content.stringContent, keyStore,
               allowedArguments: allowedArguments))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,27 +1,27 @@
 name: jose
 description: Javascript Object Signing and Encryption (JOSE) library supporting JWE, JWS, JWK and JWT
-version: 0.3.3
+version: 0.4.0
 homepage: https://github.com/appsup-dart/jose
 funding:
  - https://github.com/sponsors/rbellens
 
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   crypto_keys: ^0.3.0+1
   meta: ^1.1.6
   typed_data: ^1.0.0
   x509: ^0.2.1
-  http: ^1.0.0
+  http: '>=0.13.0 <2.0.0'
   http_parser: ^4.0.0
   asn1lib: ^1.0.0
   collection: ^1.15.0
 
 dev_dependencies:
-  test: ^1.0.0
-  lints: ^2.1.0
+  test: ^1.24.4
+  lints: ^2.1.1
 
 false_secrets:
   - test/pem/*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,14 +7,14 @@ funding:
 
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   crypto_keys: ^0.3.0+1
   meta: ^1.1.6
   typed_data: ^1.0.0
   x509: ^0.2.1
-  http: ^0.13.0
+  http: ^1.0.0
   http_parser: ^4.0.0
   asn1lib: ^1.0.0
   collection: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jose
 description: Javascript Object Signing and Encryption (JOSE) library supporting JWE, JWS, JWK and JWT
-version: 0.4.0
+version: 0.3.4
 homepage: https://github.com/appsup-dart/jose
 funding:
  - https://github.com/sponsors/rbellens

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.0.0
-  pedantic: ^1.9.0
+  lints: ^2.1.0
 
 false_secrets:
   - test/pem/*

--- a/test/jwa_test.dart
+++ b/test/jwa_test.dart
@@ -10,7 +10,7 @@ void main() {
       var data = utf8.encode('hello world');
 
       for (var a in JsonWebAlgorithm.allAlgorithms) {
-        print('${a.name}');
+        print(a.name);
         var keyPair = a.generateCryptoKeyPair();
 
         var key = a.jwkFromCryptoKeyPair(keyPair);

--- a/test/jwe_test.dart
+++ b/test/jwe_test.dart
@@ -297,7 +297,7 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded) {
       : JsonWebKeySet.fromKeys(key == null ? [] : [key]);
   var context = JsonWebKeyStore()..addKeySet(keys);
 
-  Future<void> _expectPayload(JsonWebEncryption jwe) async {
+  Future<void> expectPayload(JsonWebEncryption jwe) async {
     var content = await jwe.getPayload(context);
     if (payload is String) {
       expect(content.stringContent, payload);
@@ -316,7 +316,7 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded) {
     }
   });
   test('decrypt', () async {
-    await _expectPayload(jwe);
+    await expectPayload(jwe);
   });
   test('create', () async {
     var builder = JsonWebEncryptionBuilder()
@@ -338,6 +338,6 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded) {
     jwe = builder.build();
 
     if (encoded is String) jwe.toCompactSerialization();
-    await _expectPayload(jwe);
+    await expectPayload(jwe);
   });
 }

--- a/test/jws_test.dart
+++ b/test/jws_test.dart
@@ -228,7 +228,7 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded,
       : JsonWebKeySet.fromKeys(key == null ? [] : [key]);
   var context = JsonWebKeyStore()..addKeySet(keys);
 
-  Future<void> _expectPayload(
+  Future<void> expectPayload(
     JoseObject jose, {
     List<String>? allowedAlgorithms,
   }) async {
@@ -244,7 +244,7 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded,
   }
 
   test('decode', () {
-    _expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
+    expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
     if (encoded is String) {
       expect(jws.toCompactSerialization(), encoded);
     } else {
@@ -252,7 +252,7 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded,
     }
   });
   test('verify', () async {
-    await _expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
+    await expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
   });
   test('create', () async {
     var builder = JsonWebSignatureBuilder()..content = payload;
@@ -268,6 +268,6 @@ void _doTests(dynamic payload, dynamic key, dynamic encoded,
     var jws = builder.build();
 
     if (encoded is String) jws.toCompactSerialization();
-    await _expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
+    await expectPayload(jws, allowedAlgorithms: allowedAlgorithms);
   });
 }

--- a/test/jwt_test.dart
+++ b/test/jwt_test.dart
@@ -75,7 +75,7 @@ void main() {
             'W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U'
       }));
 
-    void _doTests(dynamic payload, dynamic encoded, [bool verify = true]) {
+    void doTests(dynamic payload, dynamic encoded, [bool verify = true]) {
       test('decode', () async {
         var jwt = await JsonWebToken.decodeAndVerify(encoded, context,
             allowedArguments: verify ? null : ['none']);
@@ -98,7 +98,7 @@ void main() {
     }
 
     group('Example JWT', () {
-      _doTests(
+      doTests(
           {'iss': 'joe', 'exp': 1300819380, 'http://example.com/is_root': true},
           'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.'
           'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
@@ -106,7 +106,7 @@ void main() {
           'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
     });
     group('Example Unsecured JWT', () {
-      _doTests(
+      doTests(
           {'iss': 'joe', 'exp': 1300819380, 'http://example.com/is_root': true},
           'eyJhbGciOiJub25lIn0.'
           'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
@@ -114,7 +114,7 @@ void main() {
           false);
     });
     group('Example Encrypted JWT', () {
-      _doTests(
+      doTests(
           {'iss': 'joe', 'exp': 1300819380, 'http://example.com/is_root': true},
           'eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.'
           'QR1Owv2ug2WyPBnbQrRARTeEk9kDO2w8qDcjiHnSJflSdv1iNqhWXaKH4MqAkQtM'
@@ -129,7 +129,7 @@ void main() {
           'fiK51VwhsxJ-siBMR-YFiA');
     });
     group('Example Nested JWT', () {
-      _doTests(
+      doTests(
           {'iss': 'joe', 'exp': 1300819380, 'http://example.com/is_root': true},
           'eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiY3R5IjoiSldU'
           'In0.'


### PR DESCRIPTION
This PR migrates to dart 3 by setting the sdk constraint. This follows the update to http: 1.0.0. While doing those upgrades I migrated from deprecated pedantic to the lints package and solved all of the linting issues, including solidifying typing where appropriate.

instead of adjusting the const names I added an ignore `constant_identifier_names` to jwa.dart. I felt this was more appropriate over renaming.

Modified SDK constraint:   `sdk: '>=3.0.0 <4.0.0'`

fixes #52 