### PR TITLE
Fixed typo P-256 to P-256K in es256k constant description

### DIFF
--- a/lib/src/jwa.dart
+++ b/lib/src/jwa.dart
@@ -121,7 +121,7 @@ class JsonWebAlgorithm {
   static const es512 =
       JsonWebAlgorithm('ES512', type: 'EC', use: 'sig', curve: 'P-521');
 
-  /// ECDSA using P-256 and SHA-256
+  /// ECDSA using P-256K and SHA-256
   static const es256k =
       JsonWebAlgorithm('ES256K', type: 'EC', use: 'sig', curve: 'P-256K');
 


### PR DESCRIPTION
`es256` and `es256k` have the same description.

https://pub.dev/documentation/jose/latest/jose/JsonWebAlgorithm-class.html#es256k

<img width="407" alt="image" src="https://github.com/user-attachments/assets/7e16c134-49db-4134-88f4-ebd030a3f5b3">
